### PR TITLE
Add date to posts

### DIFF
--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -1,6 +1,5 @@
 import NextImage from "next/image";
 import Link from "next/link";
-import { useState } from "react";
 import { HEADLINES, HeadlineProps } from "data/jokes";
 import { tweetEncoder } from "utilities/encoder";
 
@@ -26,7 +25,6 @@ interface JokeProps {
 }
 
 const Joke = ({ joke }: JokeProps) => {
-  const [isShown, setIsShown] = useState(false);
   const dateArray = joke.pubDate.toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
@@ -72,19 +70,13 @@ const Joke = ({ joke }: JokeProps) => {
                 </a>
               </Link>
             </div>
-            <div
-              className="mb-3 lg:mb-7 mr-2 object-right w-24 text-right hover:underline"
-              onMouseEnter={() => setIsShown(true)}
-              onMouseLeave={() => setIsShown(false)}
-            >
+            <div className="mb-3 lg:mb-7 mr-2 object-right w-24 text-right hover:text-black group">
               {month} {day}
+              <div className="bg-gray-500 text-white opacity-70 text-sm mr-2 object-right absolute bottom-2 -right-5 inline-block text-right hidden group-hover:block">
+                {weekday} &#183; {month} {day}, {year}
+              </div>
             </div>
           </div>
-          {isShown && (
-          <div className="bg-gray-500 text-white opacity-80 text-sm mr-2 z-[100] object-right absolute bottom-2 -right-5 inline-block text-right">
-            {weekday} &#183; {month} {day}, {year}
-            </div>
-           )}
         </div>
       </div>
     </>

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -1,5 +1,6 @@
 import NextImage from "next/image";
 import Link from "next/link";
+import { useState } from "react";
 import { HEADLINES, HeadlineProps } from "data/jokes";
 import { tweetEncoder } from "utilities/encoder";
 
@@ -25,6 +26,10 @@ interface JokeProps {
 }
 
 const Joke = ({ joke }: JokeProps) => {
+  const [isShown, setIsShown] = useState(false);
+  const dateArray = joke.pubDate.toDateString().split(" ");
+  const [weekday, month, day, year] = dateArray;
+
   const anchorString = joke.anchor ? joke.anchor.toString() : "00000";
   const hrefString = tweetEncoder(
     joke.headline,
@@ -57,13 +62,29 @@ const Joke = ({ joke }: JokeProps) => {
             />
           </div>
         )}
-        <div className="w-full mb-3 lg:mb-7 text-gray-500 ">
-          share this on{" "}
-          <Link href={hrefString}>
-            <a target="_blank" rel="noopener noreferrer">
-              <span className="text-gray-700">twitter</span>
-            </a>
-          </Link>
+        <div className="flex flex-col w-full text-gray-500 relative">
+          <div className="flex flex-row w-full justify-between">
+            <div className="mb-3 lg:mb-7 ">
+              share this on{" "}
+              <Link href={hrefString}>
+                <a target="_blank" rel="noopener noreferrer">
+                  <span className="text-gray-700">twitter</span>
+                </a>
+              </Link>
+            </div>
+            <div
+              className="mb-3 lg:mb-7 mr-2 object-right w-24 text-right hover:underline"
+              onMouseEnter={() => setIsShown(true)}
+              onMouseLeave={() => setIsShown(false)}
+            >
+              {month} {day}
+            </div>
+          </div>
+          {isShown && (
+          <div className="bg-gray-500 text-white opacity-80 text-sm mr-2 z-[100] object-right absolute bottom-2 -right-5 inline-block text-right">
+            {weekday} &#183; {month} {day}, {year}
+            </div>
+           )}
         </div>
       </div>
     </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
   mode: "jit",
   theme: {
     fontFamily: {
-      'bebas': ['"Bebas Neue"', 'cursive'], 
+      'bebas': ['"Bebas Neue"', 'cursive'],
       'montserrat': ['Montserrat', 'sans-serf'],
       'playfair': ['"Playfair Display"', 'serif']
     },
@@ -22,15 +22,16 @@ module.exports = {
       },
       backgroundImage: {
         'purple-web': "url('/assets/newsletter_web.png')"
-      }, 
+      },
       boxShadow: {
         "card": "0px 0px 4px 1px #D1D1D1"
       }
     }
   },
   variants: {
-    extend: {},
+    extend: {
+      display: ["group-hover"],
+    },
   },
   plugins: [],
 };
-


### PR DESCRIPTION
## Add date to posts
Fixes #37 

- Add base date of post. Use CSS hover to show full date with day. 

Inspired by twitter date styling with overlaid detail on hover:
<img width="675" alt="Screen Shot 2022-01-28 at 5 25 46 PM" src="https://user-images.githubusercontent.com/70108137/151629867-99556881-37f0-4b42-ad72-61276027d8fb.png">

**Demo:**
Full Screen:
https://user-images.githubusercontent.com/70108137/151630742-294f3a63-b75e-4ddb-aa7e-5c22f79d0bb9.mov

Show base date on mobile without hover effect:
<img width="528" alt="Screen Shot 2022-01-28 at 5 29 17 PM" src="https://user-images.githubusercontent.com/70108137/151630243-078d924c-32a2-4c9e-ba8d-60210d7f3334.png">


