### PR TITLE
Update gpdr banner size for smaller breakpoints

### DIFF
--- a/components/GDPR/GDPR.tsx
+++ b/components/GDPR/GDPR.tsx
@@ -60,12 +60,12 @@ const GDPR = () => {
         ref={gdprBanner}
         className="fixed bottom-0 bg-black z-50 lg:h-10 w-full text-white font-bold align-center flex flex-col justify-center"
       >
-        <div className="flex justify-center">
+        <div className="flex justify-center my-2 mx-2 md:mx-5 align-center">
           This site uses cookies to improve user experience. By using this site,
           you agree to our use of cookies.
           <button
             onClick={handleClick}
-            className=" ml-10 px-1.5 border border-devGreen"
+            className="px-1.5 ml-5 mr-2 md:ml-10 border border-devGreen md:w-[80px] md:h-[28px] md:whitespace-nowrap self-center"
           >
             OK, boss
           </button>

--- a/components/GDPR/GDPR.tsx
+++ b/components/GDPR/GDPR.tsx
@@ -58,7 +58,7 @@ const GDPR = () => {
       {/* GDPR banner only renders if there is no existing gdpr cookie */}
       <div
         ref={gdprBanner}
-        className="fixed bottom-0 bg-black z-50 h-10 w-full text-white font-bold align-center flex flex-col justify-center"
+        className="fixed bottom-0 bg-black z-50 lg:h-10 w-full text-white font-bold align-center flex flex-col justify-center"
       >
         <div className="flex justify-center">
           This site uses cookies to improve user experience. By using this site,


### PR DESCRIPTION
## Problem
GDPR banner is smaller than text area at smaller breakpoints, as shown:

**`sm` breakpoint - text and button overflow container:**
<img width="863" alt="Screen Shot 2022-01-31 at 1 24 08 PM" src="https://user-images.githubusercontent.com/70108137/151850982-d6268d6a-3ceb-4fdc-ac1a-783f79152a8e.png">

** `md` breakpoint - button overflows container:**
<img width="1026" alt="Screen Shot 2022-01-31 at 10 49 27 AM" src="https://user-images.githubusercontent.com/70108137/151826163-4f6a204f-f1ae-4cb2-a3b9-edbbc8699f94.png">

## Solution
Implement fixed height at `lg` breakpoint. For smaller breakpoints, flex container grows with content:

**`sm` breakpoint - Iphone SE:**
<img width="1141" alt="Screen Shot 2022-01-31 at 10 47 06 AM" src="https://user-images.githubusercontent.com/70108137/151825737-d27da511-934e-44e2-a4d1-d0f38ac62897.png">

**`md` breakpoint:**
<img width="987" alt="Screen Shot 2022-01-31 at 10 48 17 AM" src="https://user-images.githubusercontent.com/70108137/151825962-fcc64e57-7953-413e-882b-397cd82c97af.png">

## Preview:
preview [here](https://downtime-git-delia-fix-cookies-alert-mobile-gravitational.vercel.app/)