### PR TITLE
add RSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+public/feed.xml

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 .vercel
 
 public/feed.xml
+scripts/gen-rss.js
+data/jokes.js

--- a/data/jokes.ts
+++ b/data/jokes.ts
@@ -245,15 +245,6 @@ const RawJokes: HeadlineProps[] = [
     pubDate: new Date(2022, 1, 8),
     anchor: 10029,
   },
-  {
-    smoker: "Testing:",
-    headline:
-      "Testing with smoker 2",
-    image: "/assets/images/birdsBeesCapTalk@2x.jpg",
-    twitterImage: "pic.twitter.com/vWmyeyiL6V",
-    pubDate: new Date(2022, 1, 9),
-    anchor: 10031,
-  },
 ];
 
 //sorted into order by MOST RECENT DATE FIRST

--- a/data/jokes.ts
+++ b/data/jokes.ts
@@ -1,10 +1,7 @@
-//image imports: static imports probably better for performance, but will need to test
-import coffee from "../public/assets/images/coffee@2x.jpg";
-
 export interface HeadlineProps {
   smoker?: string;
   headline: string;
-  image?: StaticImageData | string;
+  image?: string;
   twitterImage: string;
   pubDate: Date;
   anchor?: number;
@@ -157,7 +154,7 @@ const RawJokes: HeadlineProps[] = [
   {
     smoker: "Report:",
     headline: "Spilled Coffee Remains Nation's Leading Cybersecurity Threat",
-    image: coffee,
+    image: "/assets/images/coffee@2x.jpg",
     twitterImage: "pic.twitter.com/2359Rql36C",
     pubDate: new Date(2022, 0, 12),
     anchor: 10000,

--- a/data/jokes.ts
+++ b/data/jokes.ts
@@ -248,11 +248,11 @@ const RawJokes: HeadlineProps[] = [
   {
     smoker: "Testing:",
     headline:
-      "Testing with smoker",
+      "Testing with smoker 2",
     image: "/assets/images/birdsBeesCapTalk@2x.jpg",
     twitterImage: "pic.twitter.com/vWmyeyiL6V",
-    pubDate: new Date(2022, 1, 8),
-    anchor: 10030,
+    pubDate: new Date(2022, 1, 9),
+    anchor: 10031,
   },
 ];
 

--- a/data/jokes.ts
+++ b/data/jokes.ts
@@ -245,6 +245,15 @@ const RawJokes: HeadlineProps[] = [
     pubDate: new Date(2022, 1, 8),
     anchor: 10029,
   },
+  {
+    smoker: "Testing:",
+    headline:
+      "Testing with smoker",
+    image: "/assets/images/birdsBeesCapTalk@2x.jpg",
+    twitterImage: "pic.twitter.com/vWmyeyiL6V",
+    pubDate: new Date(2022, 1, 8),
+    anchor: 10030,
+  },
 ];
 
 //sorted into order by MOST RECENT DATE FIRST

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "tsc ./scripts/gen-rss.ts && node ./scripts/gen-rss.js && next build",
     "start": "next start",
     "lint": "eslint --quiet \"(pages|components)/**/*.{js,jsx}\"",
     "format": "prettier --write \"(pages|components)/**/*.{js,jsx,ts,tsx,json}\""
@@ -17,6 +17,7 @@
     "postcss": "^8.4.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "rss": "^1.2.2",
     "tailwindcss": "^2.2.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "tsc ./scripts/gen-rss.ts && node ./scripts/gen-rss.js && next build",
+    "build": "tsc scripts/gen-rss.ts && node scripts/gen-rss.js && next build",
     "start": "next start",
     "lint": "eslint --quiet \"(pages|components)/**/*.{js,jsx}\"",
     "format": "prettier --write \"(pages|components)/**/*.{js,jsx,ts,tsx,json}\""

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+const RSS = require("rss");
+import { HEADLINES } from "../data/jokes";
+
+function generate() {
+  const feed = new RSS({
+    title: "downtime.dev",
+    description: "Hard-hitting tech news while your code compiles.",
+    site_url: "https://www.downtime.dev",
+    feed_url: "https://www.downtime.dev/feed.xml",
+  });
+
+  HEADLINES.forEach((headline) => {
+    feed.item({
+      title: headline.smoker ? `${headline.smoker} ${headline.headline}` : headline.headline,
+      description: `${feed.site_url}${headline.image}`,
+      url: `${feed.site_url}/#${headline.anchor}`,
+      date: headline.pubDate,
+    });
+  });
+
+  fs.writeFileSync("./public/feed.xml", feed.xml({ indent: true }));
+}
+
+generate();

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import { writeFileSync } from "fs";
 const RSS = require("rss");
 import { HEADLINES } from "../data/jokes";
 
@@ -19,7 +19,7 @@ function generate() {
     });
   });
 
-  fs.writeFileSync("./public/feed.xml", feed.xml({ indent: true }));
+  writeFileSync("./public/feed.xml", feed.xml({ indent: true }));
 }
 
 generate();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,6 +3411,18 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+mime-db@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+  integrity sha1-wY29fHOl2/b0SgJNwNFloeexw5I=
+
+mime-types@2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  integrity sha1-4HqqnGxrmnyjASxpADrSWjnpKog=
+  dependencies:
+    mime-db "~1.25.0"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -4209,6 +4221,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rss@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
+  integrity sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=
+  dependencies:
+    mime-types "2.1.13"
+    xml "1.0.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -4796,6 +4816,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xml@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Addresses #38 
(let's not close this issue until Step 2 has actually taken place - Cole)

## Problem
Update a Slack channel when a new joke posts

## Plan
This PR completes Step 1. Step 2 will need to be completed in Slack after merging into `main`.

### Step 1:
Add RSS feed to `downtime.dev`, following the example [blog with RSS](https://github.com/vercel/next.js/tree/canary/examples/blog) provided by NextJS. 
- Add the [RSS](https://www.npmjs.com/package/rss) npm package
- Write a function in [scripts/gen-rss.ts](https://github.com/gravitational/downtime/blob/f7b3712836ea490c6f053d0e960692c420a9fd2c/scripts/gen-rss.ts) to generate the XML file for RSS
- Update the build script to execute the generator file before running `next build`

The generated XML will be accessible by appending `/feed.xml` to the root website url. In production that will be `https://www.downtime.dev/feed.xml`

Currently, it can accessed by appending `/feed.xml` to the preview link: [https://downtime-git-delia-add-rss-gravitational.vercel.app/feed.xml](https://downtime-git-delia-add-rss-gravitational.vercel.app/feed.xml)
<img width="1440" alt="Screen Shot 2022-02-07 at 12 32 37 PM" src="https://user-images.githubusercontent.com/70108137/152841086-7eadb38b-9157-4a06-941e-9408733c628a.png">

**Checks:**
1. Validated the preview feed at  http://validator.w3.org/feed/. Evaluated as a valid RSS feed. See validation results [here](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fdowntime-git-delia-add-rss-gravitational.vercel.app%2Ffeed.xml)

2. Tested RSS feed with preview link

Joke without smoker:
<img width="735" alt="Screen Shot 2022-02-08 at 11 38 29 AM" src="https://user-images.githubusercontent.com/70108137/153033865-b3ef98f1-dfe8-4c31-bab9-9d34099b5dd2.png">

Joke with smoker:
<img width="725" alt="Screen Shot 2022-02-08 at 11 38 19 AM" src="https://user-images.githubusercontent.com/70108137/153033913-fa20ba98-a439-4207-8740-df3cd5d21da5.png">

**Notes:**
This implementation of RSS works using relative URL strings for image imports. The following errors occurred with a 
 static image import in `data/jokes.ts`. Updating the single static import to a relative URL string and removing the `StaticImageData` type fixed these errors. I can look into other solutions if static imports are preferred. 
<img width="1025" alt="Screen Shot 2022-02-07 at 1 05 45 PM" src="https://user-images.githubusercontent.com/70108137/152846259-d49e49d6-3516-426e-8c0a-e09f1dd504ee.png">

### Step 2:
Follow the [Slack instructions for adding an RSS feed](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack). Step 1 of Slack's instructions (installing the RSS app) will need to be completed by someone with Slack Workspace Owner permissions:
<img width="1915" alt="Screen Shot 2022-02-07 at 12 43 38 PM" src="https://user-images.githubusercontent.com/70108137/152843239-774cfe6f-b03f-43a0-a5f0-86948ab0e412.png">

