### PR TITLE
Update nanoid dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,12 +2780,7 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
-
-nanoid@^3.2.0:
+nanoid@^3.1.30, nanoid@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==


### PR DESCRIPTION
## Problem 
nanoid sub-dependency had security vulnerability, as seen with `yarn audit`:

<img width="650" alt="Screen Shot 2022-02-08 at 2 19 37 PM" src="https://user-images.githubusercontent.com/70108137/153059801-a444b673-2fc2-4acd-a8ce-28f082ad2199.png">

## Solution
Update nanoid version with `npx yarn-audit-fix`. `yarn audit` shows no vulnerabilities:

<img width="412" alt="Screen Shot 2022-02-08 at 2 18 41 PM" src="https://user-images.githubusercontent.com/70108137/153059695-b350d7ce-119e-47d1-a551-cf3b914ab538.png">

