### PR TITLE
Add Google Tag Manager

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,16 +4,18 @@ import type { AppProps } from "next/app";
 import Layout from "components/Layout";
 import Head from "components/Head";
 import "../styles/globals.css";
-import { pageview } from "utilities/google/gtag";
+import { GTAGPageView } from "utilities/google/gtag";
+import { GTMPageView } from "utilities/google/gtm";
 import Script from "next/script";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   useEffect(() => {
-    const handleRouteChange = (url: any) => {
+    const handleRouteChange = (url: URL) => {
       //utility for logging page views in Google Analytics
-      pageview(url);
+      GTAGPageView(url);
+      GTMPageView(url);
     };
     //When the component is mounted, subscribe to router changes
     //and log those page views
@@ -28,9 +30,24 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
+      {/* Google Tag Manager Start */}
+      <Script
+        id="gtm-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_ID}');
+            `,
+          }}
+      />
+      {/* Google Tag Manager End */}
       {/* Google Analytics Start */}
       <Script
-        strategy="afterInteractive"
+        strategy="afterInteractive" //default strategy
         src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GTAG_ID}`}
       />
       <Script

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -15,8 +15,13 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head></Head>
+        <Head />
         <body>
+          <noscript
+            dangerouslySetInnerHTML={{
+              __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_ID}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+            }}
+          />
           <Main />
           <NextScript />
         </body>

--- a/utilities/google/gtag.ts
+++ b/utilities/google/gtag.ts
@@ -1,8 +1,8 @@
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url: URL) => {
+export const GTAGPageView = (url: URL) => {
   //"as string" added per https://stackoverflow.com/questions/68136888/types-gtag-js-error-argument-of-type-config-is-not-assignable-to-parameter
-  window.gtag('config', process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS as string, {
+  window.gtag('config', process.env.NEXT_PUBLIC_GTAG_ID as string, {
     page_path: url,
   })
 }

--- a/utilities/google/gtm.ts
+++ b/utilities/google/gtm.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    dataLayer: Record<string, any>
+  }
+}
+
+export const GTMPageView = (url : URL) => {
+  window.dataLayer.push({
+    event: 'pageview',
+    page: url,
+  })
+}


### PR DESCRIPTION
- Implement GTM per official [next example](https://github.com/vercel/next.js/tree/canary/examples/with-google-tag-manager)