### PR TITLE
Add regex for twitterImage parsing

### DIFF
--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -26,15 +26,21 @@ interface JokeProps {
 }
 
 const Joke = ({ joke }: JokeProps) => {
-  const { smoker, headline, image, pubDate, anchor, twitterImage } =
-    joke.fields;
+  const {
+    smoker,
+    headline,
+    image,
+    pubDate,
+    anchor,
+    twitterHtmlEmbedFull,
+  } = joke.fields;
 
   const dateArray = new Date(pubDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
   const anchorString = anchor || "00000";
 
-  const hrefString = tweetEncoder(headline, anchorString, twitterImage);
+  const hrefString = tweetEncoder(headline, anchorString, twitterHtmlEmbedFull);
 
   return (
     <>

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -26,21 +26,15 @@ interface JokeProps {
 }
 
 const Joke = ({ joke }: JokeProps) => {
-  const {
-    smoker,
-    headline,
-    image,
-    pubDate,
-    anchor,
-    twitterHtmlEmbedFull,
-  } = joke.fields;
+  const { smoker, headline, image, pubDate, anchor, twitterEmbeddedCode } =
+    joke.fields;
 
   const dateArray = new Date(pubDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
   const anchorString = anchor || "00000";
 
-  const hrefString = tweetEncoder(headline, anchorString, twitterHtmlEmbedFull);
+  const hrefString = tweetEncoder(headline, anchorString, twitterEmbeddedCode);
 
   return (
     <>

--- a/components/JokeParser/types.ts
+++ b/components/JokeParser/types.ts
@@ -9,9 +9,8 @@ export interface RawJoke {
 interface Fields {
   headline: string;
   image: Image;
-  twitterImage: string;
   pubDate: string;
-  twitterHtmlEmbedFull: string;
+  twitterEmbeddedCode: string;
   smoker: string;
   anchor: string;
 }

--- a/data/jokes.ts
+++ b/data/jokes.ts
@@ -18,6 +18,7 @@ export interface HeadlineProps {
 }
 
 //IMPORTANT: the MONTH is zero-indexed, e.g. "0" = January, "11" = December
+
 const RawJokes: HeadlineProps[] = [
   {
     headline: "Additional Monitor To Make Everything Better",

--- a/data/jokes.ts
+++ b/data/jokes.ts
@@ -18,7 +18,6 @@ export interface HeadlineProps {
 }
 
 //IMPORTANT: the MONTH is zero-indexed, e.g. "0" = January, "11" = December
-
 const RawJokes: HeadlineProps[] = [
   {
     headline: "Additional Monitor To Make Everything Better",

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,16 +1,9 @@
-const twitterImageURLParser = (codeSnippet: string) => {
-  const re = new RegExp(/pic\.twitter\.com\/[a-zA-Z0-9]*/);
-  const parsedLinkArray = re.exec(codeSnippet);
-  return parsedLinkArray ? parsedLinkArray[0] : null;
-};
-
 export const tweetEncoder = (
   headline: string,
   anchor: string,
-  image: string
+  embeddedCode: string
 ): string => {
-
-  const twitterImageURL = twitterImageURLParser(image)
+  const twitterImageURL = twitterImageURLParser(embeddedCode);
 
   return twitterImageURL
     ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(
@@ -19,4 +12,23 @@ export const tweetEncoder = (
     : `https://twitter.com/intent/tweet?text=${encodeURIComponent(
         headline
       )}%20https%3A%2F%2Fdowntime.dev/%23${anchor}`;
+};
+
+/*
+`codeSnippet` variable is the embedded code from Twitter. It resembles:
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">captcha 
+<a href="https://t.co/DaM225rhMS">pic.twitter.com/DaM225rhMS</a>
+</p>&mdash; Sam777 (@Sam77757865973) <a 
+href="https://twitter.com/Sam77757865973/status/1496208448786243584?ref_src=twsrc%5Etfw"
+>February 22, 2022</a></blockquote> 
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
+
+This function parses the image link (for example: pic.twitter.com/DaM225rhMS) 
+from the code snippet
+*/
+
+const twitterImageURLParser = (codeSnippet: string) => {
+  const re = new RegExp(/pic\.twitter\.com\/[a-zA-Z0-9]*/);
+  const parsedLinkArray = codeSnippet.match(re);
+  return parsedLinkArray ? parsedLinkArray[0] : null;
 };

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,5 +1,22 @@
+const twitterImageURLParser = (codeSnippet: string) => {
+  const re = new RegExp(/pic\.twitter\.com\/[a-zA-Z0-9]*/);
+  const parsedLinkArray = re.exec(codeSnippet);
+  return parsedLinkArray ? parsedLinkArray[0] : null;
+};
 
+export const tweetEncoder = (
+  headline: string,
+  anchor: string,
+  image: string
+): string => {
 
-export const tweetEncoder = (headline: string, anchor: string, image: string): string => {
-  return `https://twitter.com/intent/tweet?text=${encodeURIComponent(headline)}%20https%3A%2F%2Fdowntime.dev/%23${anchor}%20${image}`
-}
+  const twitterImageURL = twitterImageURLParser(image)
+
+  return twitterImageURL
+    ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+        headline
+      )}%20https%3A%2F%2Fdowntime.dev/%23${anchor}%20${twitterImageURL}`
+    : `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+        headline
+      )}%20https%3A%2F%2Fdowntime.dev/%23${anchor}`;
+};


### PR DESCRIPTION
## Updates:
1. update content model on [Contentful](https://app.contentful.com/spaces/9l2srfbba2yk/content_types) 
- embedded code from Twitter should be pasted directly into the "twitterEmbeddedCode" field, which is now required
- removed any additional fields relating to Twitter from Contentful
<img width="1034" alt="Screen Shot 2022-02-22 at 5 28 26 PM" src="https://user-images.githubusercontent.com/70108137/155230250-0a785b51-1937-4f04-8c20-06bb974fe9fc.png">

2. Update `RawJoke` type to match Contentful model updates

3. Call a regex function from `tweetEncoder` to parse the Twitter image link from the embedded code. Update `tweetEncoder` to handle a null value from the parser in case incorrect information is added to "twitterEmbeddedCode" field

## Testing
- If twitter image link is unable to be parsed from the embedded code, twitter link looks like: 
- preview joke [here](https://downtime-git-delia-contentfuladd-regex-gravitational.vercel.app/#10026)
<img width="596" alt="Screen Shot 2022-02-22 at 5 40 30 PM" src="https://user-images.githubusercontent.com/70108137/155231730-800d8c2e-40c2-4be6-af87-b6cf83f298cb.png">

- With successful parsing, twitter link displays as expected: 
- preview joke [here](https://downtime-git-delia-contentfuladd-regex-gravitational.vercel.app/#10028)
<img width="598" alt="Screen Shot 2022-02-22 at 5 41 26 PM" src="https://user-images.githubusercontent.com/70108137/155231821-8a14c33c-af08-4540-bf08-022cf63e8e26.png">

