### PR TITLE
Update content model

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_HOST=http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_HOST=https://www.downtime.dev

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,7 @@ yarn-error.log*
 # local env files
 .env.local
 .env.test.local
-.env.development
 .env.development.local
-.env.production
 .env.production.local
 
 # vercel

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,10 @@ yarn-error.log*
 
 # local env files
 .env.local
-.env.development.local
 .env.test.local
+.env.development
+.env.development.local
+.env.production
 .env.production.local
 
 # vercel

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -25,7 +25,7 @@ const Head = ({
 
 
   const title = isHomePage ? "Hard-hitting news for when your code is compiling." : headline;
-  const description = "Hard-hitting news for when your code is compiling."
+  const description = "Hard-hitting news while your code compiles."
 
   return (
     <NextHead>

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -34,7 +34,7 @@ const Head = ({
       <link rel="icon" href="/assets/favicon.ico" />
       <link rel="icon" href="/assets/favicon.ico" type="image/x-icon" />
       <link rel="apple-touch-icon" href="/assets/favicon.ico" />
-      <meta name="description" content={`${description}`} />
+      <meta name="description" content={description} />
       <style>
         @import
         url(&apos;https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap&apos;);{" "}

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -5,44 +5,26 @@ import React from "react";
 const host = process.env.NEXT_PUBLIC_HOST;
 
 export interface HeadProps {
-  noIndex?: boolean;
   imageURL?: string;
-  smoker?: string | undefined;
   headline?: string;
   isHomePage?: boolean;
 }
 
-const setTitle = (
-  isHomePage: boolean,
-  smoker: string | undefined,
-  headline: string | undefined
-): string | undefined => {
-  let title;
-  if (isHomePage) {
-    title = "Hard-hitting news for when your code is compiling.";
-  } else {
-    title = smoker ? `${smoker} ${headline}` : headline;
-  }
-
-  return title;
-};
-
 const Head = ({
   isHomePage = false,
-  noIndex,
   imageURL,
-  smoker,
   headline,
 }: HeadProps) => {
   const router = useRouter();
   const urlSlug = router.asPath;
   const url = `${host}${urlSlug}`;
-  console.log("host", host)
+
   const imagePath = isHomePage
     ? "https://www.downtime.dev/assets/images/bored@2x.jpg"
     : `https:${imageURL}`;
 
-  const title = setTitle(isHomePage, smoker, headline);
+
+  const title = isHomePage ? "Hard-hitting news for when your code is compiling." : headline;
   const description = "Hard-hitting news for when your code is compiling."
 
   return (

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -37,6 +37,7 @@ const Head = ({
   const router = useRouter();
   const urlSlug = router.asPath;
   const url = `${host}${urlSlug}`;
+  console.log("host", host)
   const imagePath = isHomePage
     ? "https://www.downtime.dev/assets/images/bored@2x.jpg"
     : `https:${imageURL}`;
@@ -57,15 +58,15 @@ const Head = ({
         url(&apos;https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap&apos;);{" "}
       </style>
       <meta property="og:type" content="website" />
-      <meta property="og:url" content="og url" />
-      <link rel="canonical" href="cannonical url" />
+      <meta property="og:url" content={url} />
+      <link rel="canonical" href={url} />
       <meta property="og:title" content="downtime.dev" />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={imagePath} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
       <meta property="twitter:description" content={description}/>
-      <meta property="twitter:url" content="twitter url here" />
+      <meta property="twitter:url" content={url} />
       <meta property="twitter:image" content={imagePath} />
     </NextHead>
   );

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -65,9 +65,6 @@ const Head = ({
       <meta property="og:image" content={imagePath} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
-      {/* <meta property="twitter:description" content={description}/> */}
-      {/* <meta property="twitter:url" content={url} /> */}
-      {/* <meta property="twitter:image" content={imagePath} /> */}
     </NextHead>
   );
 };

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -57,15 +57,15 @@ const Head = ({
         url(&apos;https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap&apos;);{" "}
       </style>
       <meta property="og:type" content="website" />
-      <meta property="og:url" content={url} />
-      <link rel="canonical" href={url} />
+      <meta property="og:url" content="og url" />
+      <link rel="canonical" href="cannonical url" />
       <meta property="og:title" content="downtime.dev" />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={imagePath} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
       <meta property="twitter:description" content={description}/>
-      <meta property="twitter:url" content={url} />
+      <meta property="twitter:url" content="twitter url here" />
       <meta property="twitter:image" content={imagePath} />
     </NextHead>
   );

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -21,7 +21,7 @@ const setDescription = (
   if (isHomePage) {
     description = "Hard-hitting news for when your code is compiling.";
   } else {
-    description = smoker ? `${smoker}: ${headline}` : headline;
+    description = smoker ? `${smoker} ${headline}` : headline;
   }
 
   return description;

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -2,45 +2,71 @@ import NextHead from "next/head";
 import { useRouter } from "next/router";
 import React from "react";
 
-const Head = () => {
+const host = process.env.NEXT_PUBLIC_HOST;
+
+export interface HeadProps {
+  noIndex?: boolean;
+  imageURL?: string;
+  smoker?: string | undefined;
+  headline?: string;
+  isHomePage?: boolean;
+}
+
+const setDescription = (
+  isHomePage: boolean,
+  smoker: string | undefined,
+  headline: string | undefined
+): string | undefined => {
+  let description;
+  if (isHomePage) {
+    description = "Hard-hitting news for when your code is compiling.";
+  } else {
+    description = smoker ? `${smoker}: ${headline}` : headline;
+  }
+
+  return description;
+};
+
+const Head = ({
+  isHomePage = false,
+  noIndex,
+  imageURL,
+  smoker,
+  headline,
+}: HeadProps) => {
   const router = useRouter();
-  const url = router.asPath;
+  const urlSlug = router.asPath;
+  const url = `${host}${urlSlug}`;
+  const imagePath = isHomePage
+    ? "https://www.downtime.dev/assets/images/bored@2x.jpg"
+    : `https:${imageURL}`;
+
+  const title = setDescription(isHomePage, smoker, headline);
+  const description = "Hard-hitting news for when your code is compiling."
 
   return (
     <NextHead>
       <title>downtime.dev</title>
       <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <link rel="icon" href="/assets/favicon.ico" />
-      <meta
-        name="description"
-        content="Hard-hitting tech news while your code compiles."
-      />
+      <link rel="icon" href="/assets/favicon.ico" type="image/x-icon" />
+      <link rel="apple-touch-icon" href="/assets/favicon.ico" />
+      <meta name="description" content={`${description}`} />
       <style>
         @import
         url(&apos;https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap&apos;);{" "}
       </style>
       <meta property="og:type" content="website" />
       <meta property="og:url" content={url} />
+      <link rel="canonical" href={url} />
       <meta property="og:title" content="downtime.dev" />
-      <meta
-        property="og:description"
-        content="Hard-hitting news for when your code is compiling."
-      />
-      <meta
-        property="og:image"
-        content="https://www.downtime.dev/assets/images/bored@2x.jpg"
-      />
-      <meta name="twitter:card" content="summary" />
-      <meta name="twitter:title" content="downtime.dev" />
-      <meta
-        property="twitter:description"
-        content="Hard-hitting news for when your code is compiling."
-      />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={imagePath} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta property="twitter:description" content={description}/>
       <meta property="twitter:url" content={url} />
-      <meta
-        property="twitter:image"
-        content="https://www.downtime.dev/assets/images/bored@2x.jpg"
-      />
+      <meta property="twitter:image" content={imagePath} />
     </NextHead>
   );
 };

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -12,19 +12,19 @@ export interface HeadProps {
   isHomePage?: boolean;
 }
 
-const setDescription = (
+const setTitle = (
   isHomePage: boolean,
   smoker: string | undefined,
   headline: string | undefined
 ): string | undefined => {
-  let description;
+  let title;
   if (isHomePage) {
-    description = "Hard-hitting news for when your code is compiling.";
+    title = "Hard-hitting news for when your code is compiling.";
   } else {
-    description = smoker ? `${smoker} ${headline}` : headline;
+    title = smoker ? `${smoker} ${headline}` : headline;
   }
 
-  return description;
+  return title;
 };
 
 const Head = ({
@@ -41,7 +41,7 @@ const Head = ({
     ? "https://www.downtime.dev/assets/images/bored@2x.jpg"
     : `https:${imageURL}`;
 
-  const title = setDescription(isHomePage, smoker, headline);
+  const title = setTitle(isHomePage, smoker, headline);
   const description = "Hard-hitting news for when your code is compiling."
 
   return (

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -67,7 +67,6 @@ const Head = ({
       <meta name="twitter:title" content={title} />
       {/* <meta property="twitter:description" content={description}/> */}
       {/* <meta property="twitter:url" content={url} /> */}
-      <meta property="og:image" content={imagePath} />
       {/* <meta property="twitter:image" content={imagePath} /> */}
     </NextHead>
   );

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -10,22 +10,39 @@ export interface HeadProps {
   isHomePage?: boolean;
 }
 
-const Head = ({
-  isHomePage = false,
-  imageURL,
-  headline,
-}: HeadProps) => {
+/* Head component renders the meta data for each page. 
+One use of the meta data is to automatically create the summary_large_image card when sharing a url on Twitter
+
+Twitter card structures:
+
+Homepage (isHomePage = true):
+Large image
+downtime.dev
+Hard-hitting news while your code is compiling. - as title meta data
+
+
+Individual joke pages (isHomePage = false):
+Large image
+downtime.dev
+specific joke headline - as title meta data
+Hard-hitting news while your code is compiling - as og: description meta data
+*/
+
+const Head = ({ isHomePage = false, imageURL, headline }: HeadProps) => {
   const router = useRouter();
   const urlSlug = router.asPath;
   const url = `${host}${urlSlug}`;
 
+  //renders a locally stored image for homepage or a contentful image for individual joke pages
   const imagePath = isHomePage
     ? "https://www.downtime.dev/assets/images/bored@2x.jpg"
     : `https:${imageURL}`;
 
-
-  const title = isHomePage ? "Hard-hitting news for when your code is compiling." : headline;
-  const description = "Hard-hitting news while your code compiles."
+  const title = isHomePage
+    ? "Hard-hitting news while your code is compiling."
+    : headline;
+  
+  const description = "Hard-hitting news while your code compiles.";
 
   return (
     <NextHead>
@@ -42,7 +59,8 @@ const Head = ({
       <meta property="og:type" content="website" />
       <meta property="og:url" content={url} />
       <link rel="canonical" href={url} />
-      <meta property="og:title" content="downtime.dev" />
+      <meta property="og:title" content={title} />
+      {/* twitter cards only render description on individual joke pages */}
       {!isHomePage && <meta property="og:description" content={description} />}
       <meta property="og:image" content={imagePath} />
       <meta name="twitter:card" content="summary_large_image" />

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -61,13 +61,14 @@ const Head = ({
       <meta property="og:url" content={url} />
       <link rel="canonical" href={url} />
       <meta property="og:title" content="downtime.dev" />
-      <meta property="og:description" content={description} />
+      {!isHomePage && <meta property="og:description" content={description} />}
       <meta property="og:image" content={imagePath} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
-      <meta property="twitter:description" content={description}/>
-      <meta property="twitter:url" content={url} />
-      <meta property="twitter:image" content={imagePath} />
+      {/* <meta property="twitter:description" content={description}/> */}
+      {/* <meta property="twitter:url" content={url} /> */}
+      <meta property="og:image" content={imagePath} />
+      {/* <meta property="twitter:image" content={imagePath} /> */}
     </NextHead>
   );
 };

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -26,76 +26,61 @@ interface JokeProps {
 }
 
 export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
-  const {
-    smoker,
-    headline,
-    image,
-    pubDate,
-    anchor,
-    twitterEmbeddedCode,
-    slug,
-  } = joke.fields;
+  const { smoker, headline, image, pubDate, twitterEmbeddedCode, slug } =
+    joke.fields;
 
   const dateArray = new Date(pubDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
-  const anchorString = anchor || "00000";
-
-  const hrefString = tweetEncoder(headline, slug, twitterEmbeddedCode);
+  const hrefString = tweetEncoder(headline, slug);
 
   return (
-    <>
-      {/* Anchor is set above card so that navbar doesn't cover linked content */}
-      <div className={styles.anchorOuter}>
-        <a id={anchorString} rel="nofollow"></a>
-      </div>
-      <div id="card" className={styles.cardOuter}>
-        {isIndividualJoke ? (
-          <div className={styles.headline}>
+    <div id="card" className={styles.cardOuter}>
+      {isIndividualJoke ? (
+        <div className={styles.headline}>
+          <span className={styles.span1}>
+            {smoker} {headline}
+          </span>
+        </div>
+      ) : (
+        <Link href={`/jokes/${slug}`}>
+          <a className={styles.headline}>
             <span className={styles.span1}>
               {smoker} {headline}
             </span>
+          </a>
+        </Link>
+      )}
+      {image && (
+        <div className={styles.imageContainer}>
+          <NextImage
+            src={"https:" + image.fields.file.url}
+            alt="a hilariously apropos image"
+            height="400px"
+            width="600px"
+          />
+        </div>
+      )}
+      <div className={styles.shareOuter}>
+        <div className={styles.shareInner}>
+          <div className={styles.shareString}>
+            share this on{" "}
+            <Link href={hrefString}>
+              <a target="_blank" rel="noopener noreferrer">
+                <span className={styles.span2}>twitter</span>
+              </a>
+            </Link>
           </div>
-        ) : (
-          <Link href={`/jokes/${slug}`}>
-            <a className={styles.headline}>
-              <span className={styles.span1}>
-                {smoker} {headline}
-              </span>
-            </a>
-          </Link>
-        )}
-        {image && (
-          <div className={styles.imageContainer}>
-            <NextImage
-              src={"https:" + image.fields.file.url}
-              alt="a hilariously apropos image"
-              height="400px"
-              width="600px"
-            />
-          </div>
-        )}
-        <div className={styles.shareOuter}>
-          <div className={styles.shareInner}>
-            <div className={styles.shareString}>
-              share this on{" "}
-              <Link href={hrefString}>
-                <a target="_blank" rel="noopener noreferrer">
-                  <span className={styles.span2}>twitter</span>
-                </a>
-              </Link>
-            </div>
 
-            <div
-              title={`${weekday} • ${month} ${day}, ${year}`}
-              className={styles.date}
-            >
-              {month} {day}
-            </div>
+          <div
+            title={`${weekday} • ${month} ${day}, ${year}`}
+            className={styles.date}
+          >
+            {month} {day}
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -26,7 +26,7 @@ interface JokeProps {
 }
 
 export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
-  const { smoker, headline, image, pubDate, twitterEmbeddedCode, slug } =
+  const { headline, image, slug } =
     joke.fields;
 
   const firstPublishedDate = joke.sys.createdAt;
@@ -41,14 +41,14 @@ export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
       {isIndividualJoke ? (
         <div className={styles.headline}>
           <span className={styles.span1}>
-            {smoker} {headline}
+            {headline}
           </span>
         </div>
       ) : (
         <Link href={`/jokes/${slug}`}>
           <a className={styles.headline}>
             <span className={styles.span1}>
-              {smoker} {headline}
+              {headline}
             </span>
           </a>
         </Link>

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -8,6 +8,11 @@ export interface JokeParserProps {
   jokes: RawJoke[];
 }
 
+/* 
+  receives a array of jokes and maps over them to return each joke. Is used:
+  - on homepage 
+  - on individual joke pages below the top joke
+*/
 const JokeParser = ({ jokes }: JokeParserProps) => {
   return (
     <div className={styles.outer}>
@@ -25,29 +30,31 @@ interface JokeProps {
   isIndividualJoke?: boolean;
 }
 
+/* 
+  renders each joke
+  - if `isIndividualJoke=true`, this is the top joke on individual joke page. Thus joke renders without a link to joke's indivdual joke page
+*/
 export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
-  const { pubDate, headline, image, slug } =
-    joke.fields;
+  const { pubDate, headline, image, slug } = joke.fields;
 
+  //pubDate is an ISO-8601 string
   const dateArray = new Date(pubDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
+  //creates link for directly sharing joke to Twitter with joke headline and url of individual joke page pre-populated in tweet body
   const hrefString = tweetEncoder(headline, slug);
 
   return (
     <div id="card" className={styles.cardOuter}>
       {isIndividualJoke ? (
         <div className={styles.headline}>
-          <span className={styles.span1}>
-            {headline}
-          </span>
+          <span className={styles.span1}>{headline}</span>
         </div>
       ) : (
+        // Jokes rendered by JokeParser include a link to their individual joke page
         <Link href={`/jokes/${slug}`}>
           <a className={styles.headline}>
-            <span className={styles.span1}>
-              {headline}
-            </span>
+            <span className={styles.span1}>{headline}</span>
           </a>
         </Link>
       )}

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -26,12 +26,12 @@ interface JokeProps {
 }
 
 export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
-  const { headline, image, slug } =
+  const { pubDate, headline, image, slug } =
     joke.fields;
 
-  const firstPublishedDate = joke.sys.createdAt;
+  console.log("pubDate", pubDate)
 
-  const dateArray = new Date(firstPublishedDate).toDateString().split(" ");
+  const dateArray = new Date(pubDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
   const hrefString = tweetEncoder(headline, slug);

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -29,8 +29,6 @@ export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
   const { pubDate, headline, image, slug } =
     joke.fields;
 
-  console.log("pubDate", pubDate)
-
   const dateArray = new Date(pubDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 

--- a/components/JokeParser/JokeParser.tsx
+++ b/components/JokeParser/JokeParser.tsx
@@ -29,7 +29,9 @@ export const Joke = ({ joke, isIndividualJoke = false }: JokeProps) => {
   const { smoker, headline, image, pubDate, twitterEmbeddedCode, slug } =
     joke.fields;
 
-  const dateArray = new Date(pubDate).toDateString().split(" ");
+  const firstPublishedDate = joke.sys.createdAt;
+
+  const dateArray = new Date(firstPublishedDate).toDateString().split(" ");
   const [weekday, month, day, year] = dateArray;
 
   const hrefString = tweetEncoder(headline, slug);

--- a/components/JokeParser/types.ts
+++ b/components/JokeParser/types.ts
@@ -10,9 +10,6 @@ interface Fields {
   headline: string;
   image: Image;
   pubDate: string;
-  twitterEmbeddedCode: string;
-  smoker: string;
-  anchor: string;
   slug: string;
 }
 

--- a/lib/jokes.ts
+++ b/lib/jokes.ts
@@ -4,7 +4,7 @@ import { createClient } from "contentful";
 import getConfig from "./configManager";
 
 async function fetchJokesData() {
-  const config = getConfig("test-env2");
+  const config = getConfig("master");
 
   console.log("Fetching jokes data...");
 

--- a/lib/jokes.ts
+++ b/lib/jokes.ts
@@ -4,7 +4,7 @@ import { createClient } from "contentful";
 import getConfig from "./configManager";
 
 async function fetchJokesData() {
-  const config = getConfig("master");
+  const config = getConfig("test-env2");
 
   console.log("Fetching jokes data...");
 
@@ -17,7 +17,7 @@ async function fetchJokesData() {
   // fetch the raw data from Contentful
   const res = await contentfulClient.getEntries({
     content_type: "joke",
-    order: "-fields.pubDate",
+    order: "-sys.createdAt",
   });
 
   return res.items;

--- a/lib/jokes.ts
+++ b/lib/jokes.ts
@@ -17,7 +17,7 @@ async function fetchJokesData() {
   // fetch the raw data from Contentful
   const res = await contentfulClient.getEntries({
     content_type: "joke",
-    order: "-sys.createdAt",
+    order: "-fields.pubDate",
   });
 
   return res.items;

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const withVanillaExtract = createVanillaExtractPlugin();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["www.istockphoto.com", "images.ctfassets.net"]
+    domains: ["images.ctfassets.net"]
   }
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import type { AppProps } from "next/app";
 import Layout from "components/Layout";
-import Head from "components/Head";
 import "../styles/globals.css";
 import { GTAGPageView } from "utilities/google/gtag";
 import { GTMPageView } from "utilities/google/gtm";
@@ -65,7 +64,6 @@ function MyApp({ Component, pageProps }: AppProps) {
         }}
       />
       {/* Google Analytics End */}
-      <Head />
       <Layout>
         <Component {...pageProps} />
       </Layout>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ export default function Home({ jokes }: HomeProps) {
 export async function getStaticProps() {
   const jokes = await getJokes();
 
-  // await generateFeed(jokes as RawJoke[]);
+  await generateFeed(jokes as RawJoke[]);
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import { RawJoke, JokeParser } from "components/JokeParser";
+import Head from "components/Head";
 import * as styles from "components/index.css";
 import { generateFeed } from "../scripts/gen-rss";
 import getJokes from "lib/jokes";
@@ -10,6 +11,7 @@ export interface HomeProps {
 export default function Home({ jokes }: HomeProps) {
   return (
     <div className={styles.outer}>
+      <Head isHomePage />
       <Logo />
       <JokeParser jokes={jokes} />
     </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,9 +19,9 @@ export default function Home({ jokes }: HomeProps) {
 }
 
 export async function getStaticProps() {
-  const jokes = await getJokes();
+  const jokes: RawJoke[] = await getJokes();
 
-  await generateFeed(jokes as RawJoke[]);
+  await generateFeed(jokes);
 
   return {
     props: {

--- a/pages/jokes/[slug].tsx
+++ b/pages/jokes/[slug].tsx
@@ -24,7 +24,7 @@ const JokePage = ({ currentJoke, remainingJokes }: JokePageProps) => {
 };
 
 export const getStaticPaths = async () => {
-  const jokes = (await getJokes()) as RawJoke[];
+  const jokes: RawJoke[] = await getJokes();
 
   const paths = jokes.map((item) => {
     return {
@@ -41,10 +41,10 @@ export const getStaticPaths = async () => {
 };
 
 export async function getStaticProps(context: { params: { slug: any } }) {
-  const jokes = (await getJokes()) as RawJoke[];
+  const jokes: RawJoke[] = await getJokes();
 
   let currentJoke;
-  const remainingJokes = [] as RawJoke[];
+  const remainingJokes: RawJoke[] = [];
 
   jokes.forEach((joke) => {
     if (joke.fields.slug === context.params.slug) {

--- a/pages/jokes/[slug].tsx
+++ b/pages/jokes/[slug].tsx
@@ -14,7 +14,6 @@ const JokePage = ({ currentJoke, remainingJokes }: JokePageProps) => {
     <div className={styles.outer}>
       <Head
         imageURL={currentJoke.fields.image.fields.file.url}
-        smoker={currentJoke.fields.smoker}
         headline={currentJoke.fields.headline}
       />
       <Logo />

--- a/pages/jokes/[slug].tsx
+++ b/pages/jokes/[slug].tsx
@@ -1,4 +1,5 @@
 import { Joke, RawJoke, JokeParser } from "components/JokeParser";
+import Head from "components/Head";
 import Logo from "components/Logo";
 import getJokes from "lib/jokes";
 import * as styles from "components/index.css";
@@ -11,6 +12,11 @@ interface JokePageProps {
 const JokePage = ({ currentJoke, remainingJokes }: JokePageProps) => {
   return (
     <div className={styles.outer}>
+      <Head
+        imageURL={currentJoke.fields.image.fields.file.url}
+        smoker={currentJoke.fields.smoker}
+        headline={currentJoke.fields.headline}
+      />
       <Logo />
       <Joke joke={currentJoke} isIndividualJoke />
       <JokeParser jokes={remainingJokes} />

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -12,7 +12,7 @@ export async function generateFeed(jokes: RawJoke[]) {
 
   jokes.forEach((headline) => {
     feed.item({
-      title: `${headline.fields.headline}`,
+      title: headline.fields.headline,
       description: `https:${headline.fields.image.fields.file.url}`,
       url: `${feed.site_url}/jokes/${headline.fields.slug}`,
       date: headline.fields.pubDate,

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -12,9 +12,7 @@ export async function generateFeed(jokes: RawJoke[]) {
 
   jokes.forEach((headline) => {
     feed.item({
-      title: headline.fields.smoker
-        ? `${headline.fields.smoker} ${headline.fields.headline}`
-        : headline.fields.headline,
+      title: `${headline.fields.headline}`,
       description: `https:${headline.fields.image.fields.file.url}`,
       url: `${feed.site_url}/jokes/${headline.fields.slug}`,
       date: headline.fields.pubDate,

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,6 +1,6 @@
 // for testing share on twitter links with Vercel preview
 const baseUrl =
-  "https://downtime-git-delia-updates-off-107-gravitational.vercel.app/";
+  "https://downtime-git-delia-updates-off-107-gravitational.vercel.app";
 
 // const baseUrl = "https://www.downtime.dev";
 

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,35 +1,17 @@
+// for testing share on twitter links with Vercel preview
+const baseUrl =
+  "https://downtime-git-delia-ve-contentful-updates-gravitational.vercel.app";
 
-export const tweetEncoder = (
-  headline: string,
-  slug: string,
-  embeddedCode: string
-): string => {
-  const twitterImageURL = twitterImageURLParser(embeddedCode);
+// const baseUrl = process.env.NEXT_PUBLIC_HOST || "https://www.downtime.dev";
 
-  return twitterImageURL
-    ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-        headline
-      )}%20https%3A%2F%2Fdowntime.dev/jokes/${slug}%20${twitterImageURL}`
-    : `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-        headline
-      )}%20https%3A%2F%2Fdowntime.dev/jokes/${slug}`;
-};
+export const tweetEncoder = (headline: string, slug: string): string => {
+  const url = `${baseUrl}/jokes/${slug}`;
 
-/*
-`codeSnippet` variable is the embedded code from Twitter. It resembles:
-<blockquote class="twitter-tweet"><p lang="en" dir="ltr">captcha 
-<a href="https://t.co/DaM225rhMS">pic.twitter.com/DaM225rhMS</a>
-</p>&mdash; Sam777 (@Sam77757865973) <a 
-href="https://twitter.com/Sam77757865973/status/1496208448786243584?ref_src=twsrc%5Etfw"
->February 22, 2022</a></blockquote> 
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
+  // tweet summary-large-image twitter card only
+  // return `https://twitter.com/intent/tweet?text=${encodeURIComponent(url)}`
 
-This function parses the image link (for example: pic.twitter.com/DaM225rhMS) 
-from the code snippet
-*/
-
-const twitterImageURLParser = (codeSnippet: string) => {
-  const re = new RegExp(/pic\.twitter\.com\/[a-zA-Z0-9]*/);
-  const parsedLinkArray = codeSnippet.match(re);
-  return parsedLinkArray ? parsedLinkArray[0] : null;
+  // tweet headline + summary-large-image twitter card
+  return `https://twitter.com/intent/tweet?text=${headline}%20${encodeURIComponent(
+    url
+  )}`;
 };

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,6 +1,6 @@
 // for testing share on twitter links with Vercel preview
 const baseUrl =
-  "https://downtime-git-delia-updates-off-107-gravitational.vercel.app";
+  "https://downtime-git-delia-update-content-model-gravitational.vercel.app";
 
 // const baseUrl = "https://www.downtime.dev";
 

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,14 +1,11 @@
 // for testing share on twitter links with Vercel preview
 const baseUrl =
-  "https://downtime-git-delia-ve-contentful-updates-gravitational.vercel.app";
+  "https://downtime-git-delia-updates-off-107-gravitational.vercel.app/";
 
-// const baseUrl = process.env.NEXT_PUBLIC_HOST || "https://www.downtime.dev";
+// const baseUrl = "https://www.downtime.dev";
 
 export const tweetEncoder = (headline: string, slug: string): string => {
   const url = `${baseUrl}/jokes/${slug}`;
-
-  // tweet summary-large-image twitter card only
-  // return `https://twitter.com/intent/tweet?text=${encodeURIComponent(url)}`
 
   // tweet headline + summary-large-image twitter card
   return `https://twitter.com/intent/tweet?text=${headline}%20${encodeURIComponent(

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,8 +1,4 @@
-// for testing share on twitter links with Vercel preview
-const baseUrl =
-  "https://downtime-git-delia-update-content-model-gravitational.vercel.app";
-
-// const baseUrl = "https://www.downtime.dev";
+const baseUrl = "https://www.downtime.dev";
 
 export const tweetEncoder = (headline: string, slug: string): string => {
   const url = `${baseUrl}/jokes/${slug}`;


### PR DESCRIPTION
- branched off #111 ; set to merge to #107
- preview [here](https://downtime-git-delia-update-content-model-gravitational.vercel.app/)

## Update Contentful Content Model on `test-env2` Environment
**New Joke Fields:**
- headline
- slug - autogenerated as a url friendly slug based on headline
- image
- pubDate

Jokes will need to be scheduled for publishing on the desired date

## Update Head
- test urls using the [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- test home page
<img width="1044" alt="Screen Shot 2022-03-16 at 12 45 25 PM" src="https://user-images.githubusercontent.com/70108137/158642991-497fbde6-9f23-4a5c-a108-4e05b71cb504.png">

- test ind joke page:
<img width="1116" alt="Screen Shot 2022-03-16 at 2 47 10 PM" src="https://user-images.githubusercontent.com/70108137/158664739-7001d08f-929c-4980-9477-e5afdb74bfa0.png">
