### PR TITLE
Update rss feed

### DIFF
--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -18,7 +18,7 @@ export async function generateFeed(jokes: RawJoke[]) {
       description: 
       `
       <image>
-        <url>{https:${headline.fields.image.fields.file.url}}</url>
+        <url>https:${headline.fields.image.fields.file.url}</url>
         <title>a hilariously apropos image</title>
       </image>
       `,

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -13,7 +13,13 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      description: `https:${headline.fields.image.fields.file.url}`,
+      description: 
+      `
+      <image>
+        <url>{https:${headline.fields.image.fields.file.url}}</url>
+        <title>a hilariously apropos image</title>
+      </image>
+      `,
       url: `${feed.site_url}/jokes/${headline.fields.slug}`,
       date: headline.fields.pubDate,
     });

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -7,23 +7,18 @@ export async function generateFeed(jokes: RawJoke[]) {
     title: "downtime.dev",
     description: "Hard-hitting tech news while your code compiles.",
     // site_url: "https://www.downtime.dev",
-    site_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/",
+    site_url:
+      "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/",
     // feed_url: "https://www.downtime.dev/feed.xml",
-    feed_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",
+    feed_url:
+      "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",
   });
 
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      // description: 
-      // `
-      // <image>
-      //   <url>https:${headline.fields.image.fields.file.url}</url>
-      //   <title>a hilariously apropos image</title>
-      // </image>
-      // `,
       enclosure: {
-        url: `https:${headline.fields.image.fields.file.url}`
+        url: `https:${headline.fields.image.fields.file.url}`,
       },
       url: `${feed.site_url}/jokes/${headline.fields.slug}`,
       date: headline.fields.pubDate,

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -17,6 +17,7 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
+      description: "Hard-hitting news while your code compiles.",
       enclosure: {
         url: `https:${headline.fields.image.fields.file.url}`,
       },

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -17,6 +17,7 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
+      description: "A hilariously apropos image",
       enclosure: {
         url: `https:${headline.fields.image.fields.file.url}`,
       },

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -6,14 +6,16 @@ export async function generateFeed(jokes: RawJoke[]) {
   const feed = new RSS({
     title: "downtime.dev",
     description: "Hard-hitting tech news while your code compiles.",
-    site_url: "https://www.downtime.dev",
-    feed_url: "https://www.downtime.dev/feed.xml",
+    // site_url: "https://www.downtime.dev",
+    // feed_url: "https://www.downtime.dev/feed.xml",
+    site_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app",
+    feed_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",
   });
 
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      description: "A hilariously apropos image",
+      // description: "A hilariously apropos image",
       enclosure: {
         url: `https:${headline.fields.image.fields.file.url}`,
       },

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -17,7 +17,6 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      description: "A hilariously apropos image",
       enclosure: {
         url: `https:${headline.fields.image.fields.file.url}`,
       },

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -6,12 +6,8 @@ export async function generateFeed(jokes: RawJoke[]) {
   const feed = new RSS({
     title: "downtime.dev",
     description: "Hard-hitting tech news while your code compiles.",
-    // site_url: "https://www.downtime.dev",
-    site_url:
-      "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app",
-    // feed_url: "https://www.downtime.dev/feed.xml",
-    feed_url:
-      "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",
+    site_url: "https://www.downtime.dev",
+    feed_url: "https://www.downtime.dev/feed.xml",
   });
 
   jokes.forEach((headline) => {

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -15,7 +15,7 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      // description: "A hilariously apropos image",
+      description: "Hard-hitting tech news while your code compiles.",
       enclosure: {
         url: `https:${headline.fields.image.fields.file.url}`,
       },

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -17,7 +17,7 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      description: "Hard-hitting news while your code compiles.",
+      description: "A hilariously apropos image",
       enclosure: {
         url: `https:${headline.fields.image.fields.file.url}`,
       },

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -6,8 +6,10 @@ export async function generateFeed(jokes: RawJoke[]) {
   const feed = new RSS({
     title: "downtime.dev",
     description: "Hard-hitting tech news while your code compiles.",
-    site_url: "https://www.downtime.dev",
-    feed_url: "https://www.downtime.dev/feed.xml",
+    // site_url: "https://www.downtime.dev",
+    site_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/",
+    // feed_url: "https://www.downtime.dev/feed.xml",
+    feed_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",
   });
 
   jokes.forEach((headline) => {

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -15,13 +15,16 @@ export async function generateFeed(jokes: RawJoke[]) {
   jokes.forEach((headline) => {
     feed.item({
       title: headline.fields.headline,
-      description: 
-      `
-      <image>
-        <url>https:${headline.fields.image.fields.file.url}</url>
-        <title>a hilariously apropos image</title>
-      </image>
-      `,
+      // description: 
+      // `
+      // <image>
+      //   <url>https:${headline.fields.image.fields.file.url}</url>
+      //   <title>a hilariously apropos image</title>
+      // </image>
+      // `,
+      enclosure: {
+        url: `https:${headline.fields.image.fields.file.url}`
+      },
       url: `${feed.site_url}/jokes/${headline.fields.slug}`,
       date: headline.fields.pubDate,
     });

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -8,7 +8,7 @@ export async function generateFeed(jokes: RawJoke[]) {
     description: "Hard-hitting tech news while your code compiles.",
     // site_url: "https://www.downtime.dev",
     site_url:
-      "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/",
+      "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app",
     // feed_url: "https://www.downtime.dev/feed.xml",
     feed_url:
       "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",

--- a/scripts/gen-rss.ts
+++ b/scripts/gen-rss.ts
@@ -6,10 +6,8 @@ export async function generateFeed(jokes: RawJoke[]) {
   const feed = new RSS({
     title: "downtime.dev",
     description: "Hard-hitting tech news while your code compiles.",
-    // site_url: "https://www.downtime.dev",
-    // feed_url: "https://www.downtime.dev/feed.xml",
-    site_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app",
-    feed_url: "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml",
+    site_url: "https://www.downtime.dev",
+    feed_url: "https://www.downtime.dev/feed.xml",
   });
 
   jokes.forEach((headline) => {

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,5 +1,4 @@
-// const baseUrl = "https://www.downtime.dev";
-const baseUrl = "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app";
+const baseUrl = "https://www.downtime.dev";
 
 export const tweetEncoder = (headline: string, slug: string): string => {
   const url = `${baseUrl}/jokes/${slug}`;

--- a/utilities/encoder.ts
+++ b/utilities/encoder.ts
@@ -1,4 +1,5 @@
-const baseUrl = "https://www.downtime.dev";
+// const baseUrl = "https://www.downtime.dev";
+const baseUrl = "https://downtime-git-delia-update-rss-feed-gravitational.vercel.app";
 
 export const tweetEncoder = (headline: string, slug: string): string => {
   const url = `${baseUrl}/jokes/${slug}`;

--- a/utilities/getJokes.ts
+++ b/utilities/getJokes.ts
@@ -60,8 +60,7 @@ export default async function getJokes() {
 async function fetchJokesData() {
   // during development, pass string of target environment name (see ./configManager)
   // for production, getConfig() must be passed "master"
-  // const config = getConfig("master");
-  const config = getConfig("test-env1");
+  const config = getConfig("master");
 
   console.log("Fetching jokes data...");
 

--- a/utilities/getJokes.ts
+++ b/utilities/getJokes.ts
@@ -60,7 +60,8 @@ export default async function getJokes() {
 async function fetchJokesData() {
   // during development, pass string of target environment name (see ./configManager)
   // for production, getConfig() must be passed "master"
-  const config = getConfig("master");
+  // const config = getConfig("master");
+  const config = getConfig("test-env1");
 
   console.log("Fetching jokes data...");
 


### PR DESCRIPTION
# Problem
With addition of `og-image` to each page's `Head` metadata, Slack RSS plugin was duplicating images for each post:
<img width="887" alt="Screen Shot 2022-03-22 at 10 02 28 AM" src="https://user-images.githubusercontent.com/70108137/159499309-8ee7b98e-c383-4481-9245-3551c74d8ac3.png">

# Solution
- preview RSS feed [here](https://downtime-git-delia-update-rss-feed-gravitational.vercel.app/feed.xml)
- move image url from `description` key to `enclosure` key in the RSS "item" created by the [RSS package](https://github.com/dylang/node-rss)
- change `description` to "A hilariously apropos image" as skipping description caused strange side effects including:
       1. only _sometimes_ posting in Slack channel, rather than for every new post
       2. showing "no content" (see screenshot A) or declining to post the image (see screenshot B) on other RSS feed readers

**Successful Slack Post:**
<img width="495" alt="Screen Shot 2022-03-22 at 1 33 07 PM" src="https://user-images.githubusercontent.com/70108137/159541097-0a20d876-f41d-4933-a2e2-f2de09537d11.png">


### Verification:
- valid RSS feed per [W3Schools validator](https://validator.w3.org/feed/)
- Additionally, option to add "valid rss feed" link to our site if we'd like:
<img width="1433" alt="Screen Shot 2022-03-22 at 10 27 48 AM" src="https://user-images.githubusercontent.com/70108137/159504991-0eba1ec6-4aba-4980-90e4-45117e521980.png">


### Screenshots:
**A - [Feedly](https://feedly.com/):**
<img width="777" alt="Screen Shot 2022-03-22 at 1 31 27 PM" src="https://user-images.githubusercontent.com/70108137/159540926-6eddfeca-6ec8-46ab-a19c-4ca8b6dd5d9b.png">

**B - [NewsBlur](https://newsblur.com/):**
<img width="1217" alt="Screen Shot 2022-03-22 at 1 29 35 PM" src="https://user-images.githubusercontent.com/70108137/159540657-4b258516-f85d-4cd9-902c-9743c34a004b.png">

